### PR TITLE
truncate /etc/machine-id for templating

### DIFF
--- a/ubuntu/18.04/custom/preseed.cfg
+++ b/ubuntu/18.04/custom/preseed.cfg
@@ -215,6 +215,7 @@ d-i preseed/late_command string \
  in-target sh -c 'sed -i "s/^#PermitRootLogin.*\$/PermitRootLogin prohibit-password/g" /etc/ssh/sshd_config'; \
  in-target sh -c 'rm -f /etc/ssh/ssh_host_*_key* && mkdir -p /usr/lib/systemd/system && cp /custom/ssh-host-keygen.service /usr/lib/systemd/system/ssh-host-keygen.service && systemctl enable ssh-host-keygen.service'; \
  in-target sh -c 'echo "IPv4: \\\4" >> /etc/issue && echo "IPv6: \\\6" >> /etc/issue && echo "" >> /etc/issue'; \
+ in-target sh -c 'truncate -s0 /etc/machine-id'; \
  in-target sh -c 'eject || true'; \
  rm -r /target/custom;
 d-i debian-installer/splash boolean false


### PR DESCRIPTION
This is neccessary due to constraints with DHCP servers that serve IPs upon this machine-id and therefore server the same IP to machines with the same machine-id.
The machine-id gets automatically generated upon first boot.
https://manpages.ubuntu.com/manpages/bionic/man5/machine-id.5.html